### PR TITLE
Fixed check for global 'window' variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const client = new Wavelet("http://127.0.0.1:9000");
     const contract = new Contract(client, '52bb52e0440ce0aa7a7d2018f5bac21d6abde64f5b9498615ce2bef332bd487a');
     await contract.init();
 
-    console.log(contract.test('balance', BigInt(0),
+    console.log(contract.test(wallet, 'balance', BigInt(0),
         {
             type: 'raw',
             value: '400056ee68a7cc2695222df05ea76875bc27ec6e61e8e62317c336157019c405'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "utils",
     "lib",
     "wavelet",
-    "perlin",
+    "perlin"
   ],
   "dependencies": {
     "atob": "^2.1.2",

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,12 @@ const TAG_STAKE = 3;
 const TAG_BATCH = 4;
 
 const JSBI = require('jsbi');
-const BigInt = window && window.useNativeBigIntsIfAvailable ? BigInt : JSBI.BigInt;
+
+if (typeof window === 'undefined') {
+    var window = window || {};
+}
+
+const BigInt = window.useNativeBigIntsIfAvailable ? BigInt : JSBI.BigInt;
 
 /**
  * Converts a string to a Buffer.


### PR DESCRIPTION
Wrapped the check for window inside a typeof conditional. Otherwise node js environment (such as Gatsby) fail when they see undefined window variable