### PR TITLE
Fix browser support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "perlin"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.5.5",
     "atob": "^2.1.2",
     "axios": "^0.19.0",
     "core-js": "2",

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const JSBI = require('jsbi');
 
 if (typeof window === 'undefined') {
     var window = window || {};
+    var global = global || window;
 }
 
 const BigInt = window && window.useNativeBigIntsIfAvailable ? BigInt : JSBI.BigInt;

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,13 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -2678,6 +2685,11 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
 regenerator-transform@^0.14.0:
   version "0.14.0"


### PR DESCRIPTION
It includes runtimeGenerator by adding @babel/runtime dependency and wraps the 'global' variable so that it references window on browsers.

Should be able to load the script like this:
`
   <script>
       // mock require or use requireJS
        var require = () => window;
    </script>
   <script src="dist/wavelet-client.umd.js"></script>
    <script>
        console.log(window['wavelet-client']);
    </script>
`